### PR TITLE
Can be followed by a "|" and another command

### DIFF
--- a/plugin/vaffle.vim
+++ b/plugin/vaffle.vim
@@ -36,7 +36,7 @@ endfunction
 
 call s:set_up_default_config()
 
-command! -nargs=? -complete=dir Vaffle call vaffle#init(<f-args>)
+command! -bar -nargs=? -complete=dir Vaffle call vaffle#init(<f-args>)
 
 
 " Toggle


### PR DESCRIPTION
# Can be followed by a "|" and another command

## Why

I want to open Vaffle when run vim without arguments, so added the following to my `.vimrc`.

```vim
autocmd VimEnter * nested if @% == '' | Vaffle | endif
```

But the following error occurred.

```
Error detected while processing VimEnter Auto commands for "*":
E172: Only one file name allowed:  Vaffle | endif
```

## What

Use the -bar attribute when define command.
