### PR TITLE
Fix the error that generates wrong path separators

### DIFF
--- a/autoload/vaffle/env.vim
+++ b/autoload/vaffle/env.vim
@@ -29,9 +29,9 @@ endfunction
 
 
 function! vaffle#env#create_items(env) abort
-  let paths = vaffle#compat#glob_list(a:env.dir . '/*')
+  let paths = vaffle#compat#glob_list(fnamemodify(a:env.dir, ':p') . '*')
   if a:env.shows_hidden_files
-    let hidden_paths = vaffle#compat#glob_list(a:env.dir . '/.*')
+    let hidden_paths = vaffle#compat#glob_list(fnamemodify(a:env.dir, ':p') . '.*')
     " Exclude '.' & '..'
     call filter(hidden_paths, 'match(v:val, ''\(/\|\\\)\.\.\?$'') < 0')
 


### PR DESCRIPTION
When current directory is root directory (e.g. `/` or `C:/`), `vaffle#env#create_items()` generates wrong duplicated path separators (e.g. `//bin` or `C://Windows`).