### PR TITLE
Add <Plug>(vaffle-open-current-split) and <Plug>(vaffle-open-current-vsplit)

### DIFF
--- a/autoload/vaffle/buffer.vim
+++ b/autoload/vaffle/buffer.vim
@@ -16,26 +16,28 @@ endfunction
 
 function! s:set_up_default_mappings() abort
   " Toggle
-  call s:map_default('n', '<Space>', 'toggle-current',   '<buffer> <silent>')
-  call s:map_default('n', '.',       'toggle-hidden',    '<buffer> <silent>')
-  call s:map_default('n', '*',       'toggle-all',       '<buffer> <silent>')
-  call s:map_default('v', '<Space>', 'toggle-current',   '<buffer> <silent>')
+  call s:map_default('n', '<Space>', 'toggle-current',      '<buffer> <silent>')
+  call s:map_default('n', '.',       'toggle-hidden',       '<buffer> <silent>')
+  call s:map_default('n', '*',       'toggle-all',          '<buffer> <silent>')
+  call s:map_default('v', '<Space>', 'toggle-current',      '<buffer> <silent>')
   " Operations for selected items
-  call s:map_default('n', 'd',       'delete-selected',  '<buffer> <nowait> <silent>')
-  call s:map_default('n', 'x',       'fill-cmdline',     '<buffer> <silent>')
-  call s:map_default('n', 'm',       'move-selected',    '<buffer> <silent>')
-  call s:map_default('n', '<CR>',    'open-selected',    '<buffer> <silent>')
-  call s:map_default('n', 'r',       'rename-selected',  '<buffer> <silent>')
+  call s:map_default('n', 'd',       'delete-selected',     '<buffer> <nowait> <silent>')
+  call s:map_default('n', 'x',       'fill-cmdline',        '<buffer> <silent>')
+  call s:map_default('n', 'm',       'move-selected',       '<buffer> <silent>')
+  call s:map_default('n', '<CR>',    'open-selected',       '<buffer> <silent>')
+  call s:map_default('n', 'r',       'rename-selected',     '<buffer> <silent>')
   " Operations for a item on cursor
-  call s:map_default('n', 'l',       'open-current',     '<buffer> <silent>')
-  call s:map_default('n', 't',       'open-current-tab', '<buffer> <nowait> <silent>')
+  call s:map_default('n', 'l',       'open-current',        '<buffer> <silent>')
+  call s:map_default('n', 't',       'open-current-tab',    '<buffer> <nowait> <silent>')
+  call s:map_default('n', 's',       'open-current-split',  '<buffer> <nowait> <silent>')
+  call s:map_default('n', 'v',       'open-current-vsplit', '<buffer> <nowait> <silent>')
   " Misc
-  call s:map_default('n', 'o',       'mkdir',            '<buffer> <silent>')
-  call s:map_default('n', 'i',       'new-file',         '<buffer> <silent>')
-  call s:map_default('n', '~',       'open-home',        '<buffer> <silent>')
-  call s:map_default('n', 'h',       'open-parent',      '<buffer> <silent>')
-  call s:map_default('n', 'q',       'quit',             '<buffer> <silent>')
-  call s:map_default('n', 'R',       'refresh',          '<buffer> <silent>')
+  call s:map_default('n', 'o',       'mkdir',               '<buffer> <silent>')
+  call s:map_default('n', 'i',       'new-file',            '<buffer> <silent>')
+  call s:map_default('n', '~',       'open-home',           '<buffer> <silent>')
+  call s:map_default('n', 'h',       'open-parent',         '<buffer> <silent>')
+  call s:map_default('n', 'q',       'quit',                '<buffer> <silent>')
+  call s:map_default('n', 'R',       'refresh',             '<buffer> <silent>')
 
   " Removed <Esc> mappings because they cause a conflict with arrow keys in terminal...
   " In terminal, arrow keys are simulated as follows:

--- a/autoload/vaffle/file.vim
+++ b/autoload/vaffle/file.vim
@@ -3,12 +3,16 @@ set cpoptions&vim
 
 
 let s:open_mode_to_cmd_single_map = {
-      \   '':    'edit',
-      \   'tab': 'tabedit',
+      \   '':       'edit',
+      \   'tab':    'tabedit',
+      \   'split':  'split',
+      \   'vsplit': 'vsplit',
       \ }
 let s:open_mode_to_cmd_multiple_map = {
-      \   '':    'split',
-      \   'tab': 'tabedit',
+      \   '':       'split',
+      \   'tab':    'tabedit',
+      \   'split':  'split',
+      \   'vsplit': 'vsplit',
       \ }
 
 

--- a/autoload/vaffle/file.vim
+++ b/autoload/vaffle/file.vim
@@ -5,14 +5,14 @@ set cpoptions&vim
 let s:open_mode_to_cmd_single_map = {
       \   '':       'edit',
       \   'tab':    'tabedit',
-      \   'split':  'split',
-      \   'vsplit': 'vsplit',
+      \   'split':  get(g:, 'vaffle_open_current_split_location', 'topleft') . ' split',
+      \   'vsplit': get(g:, 'vaffle_open_current_vsplit_location', 'rightbelow') . ' vsplit',
       \ }
 let s:open_mode_to_cmd_multiple_map = {
       \   '':       'split',
       \   'tab':    'tabedit',
-      \   'split':  'split',
-      \   'vsplit': 'vsplit',
+      \   'split':  get(g:, 'vaffle_open_current_split_location', 'topleft') . ' split',
+      \   'vsplit': get(g:, 'vaffle_open_current_vsplit_location', 'rightbelow') . ' vsplit',
       \ }
 
 

--- a/autoload/vaffle/file.vim
+++ b/autoload/vaffle/file.vim
@@ -5,14 +5,14 @@ set cpoptions&vim
 let s:open_mode_to_cmd_single_map = {
       \   '':       'edit',
       \   'tab':    'tabedit',
-      \   'split':  get(g:, 'vaffle_open_current_split_location', 'topleft') . ' split',
-      \   'vsplit': get(g:, 'vaffle_open_current_vsplit_location', 'rightbelow') . ' vsplit',
+      \   'split':  get(g:, 'vaffle_open_current_split_position', 'topleft') . ' split',
+      \   'vsplit': get(g:, 'vaffle_open_current_vsplit_position', 'rightbelow') . ' vsplit',
       \ }
 let s:open_mode_to_cmd_multiple_map = {
       \   '':       'split',
       \   'tab':    'tabedit',
-      \   'split':  get(g:, 'vaffle_open_current_split_location', 'topleft') . ' split',
-      \   'vsplit': get(g:, 'vaffle_open_current_vsplit_location', 'rightbelow') . ' vsplit',
+      \   'split':  get(g:, 'vaffle_open_current_split_position', 'topleft') . ' split',
+      \   'vsplit': get(g:, 'vaffle_open_current_vsplit_position', 'rightbelow') . ' vsplit',
       \ }
 
 

--- a/doc/vaffle.txt
+++ b/doc/vaffle.txt
@@ -133,7 +133,23 @@ version, but not supported.
 
 
 ------------------------------------------------------------------------------
-3.3. Other Operations                             *vaffle-key-mappings-others*
+3.3. Operations for an item on cursor           *vaffle-key-mappings-currents*
+
+*<Plug>(vaffle-open-current)*
+                Open an item on the cursor.
+*<Plug>(vaffle-open-current-tab)*
+                Open an item on the cursor at a new tab.
+*<Plug>(vaffle-open-current-split)*
+                Open an item on the cursor at a splitten window.
+                If you would like to change the buffer position, refer
+                |vaffle-example-custom-window-position|.
+*<Plug>(vaffle-open-current-vsplit)*
+                Vertical split version of
+                the |<Plug>(vaffle-open-current-split)|.
+
+
+------------------------------------------------------------------------------
+3.4. Other Operations                             *vaffle-key-mappings-others*
 
 
 *<Plug>(vaffle-mkdir)*
@@ -167,25 +183,26 @@ version, but not supported.
 
   Mode  {lhs}     {rhs} ~
   ----  --------  -------------------------------- ~
+  n     ~         |<Plug>(vaffle-open-home)|
   n     h         |<Plug>(vaffle-open-parent)|
   n     l         |<Plug>(vaffle-open-current)|
-  n     ~         |<Plug>(vaffle-open-home)|
+  n     t         |<Plug>(vaffle-open-current-tab)|
+  n     s         |<Plug>(vaffle-open-current-split)|
+  n     v         |<Plug>(vaffle-open-current-vsplit)|
+
+  n     *         |<Plug>(vaffle-toggle-all)|
+  n     .         |<Plug>(vaffle-toggle-hidden)|
+  nv    <Space>   |<Plug>(vaffle-toggle-current)|
 
   n     <CR>      |<Plug>(vaffle-open-selected)|
-  n     t         |<Plug>(vaffle-open-selected-tab)|
+  n     m         |<Plug>(vaffle-move-selected)|
+  n     d         |<Plug>(vaffle-delete-selected)|
+  n     r         |<Plug>(vaffle-rename-selected)|
 
   n     q         |<Plug>(vaffle-quit)|
-  n     R         |<Plug>(vaffle-refresh)|
-  n     .         |<Plug>(vaffle-toggle-hidden)|
-
-  nv    <Space>   |<Plug>(vaffle-toggle-current)|
-  n     *         |<Plug>(vaffle-toggle-all)|
-
   n     o         |<Plug>(vaffle-mkdir)|
+  n     R         |<Plug>(vaffle-refresh)|
   n     i         |<Plug>(vaffle-new-file)|
-  n     d         |<Plug>(vaffle-delete-selected)|
-  n     m         |<Plug>(vaffle-move-selected)|
-  n     r         |<Plug>(vaffle-rename-selected)|
   n     x         |<Plug>(vaffle-fill-cmdline)|
 
 
@@ -232,6 +249,20 @@ Customizing key mappings:                 *vaffle-example-custom-key-mappings*
   augroup vimrc_vaffle
     autocmd!
     autocmd FileType vaffle call s:customize_vaffle_mappings()
+  augroup END
+<
+
+Customizing position of splitten window:
+                                        *vaffle-example-custom-window-position*
+>
+  function! s:customize_vaffle_splitten_window() abort
+    setlocal splitbelow
+    setlocal splitright
+  endfunction
+
+  augroup vimrc_vaffle
+    autocmd!
+    autocmd FileType vaffle call s:customize_vaffle_splitten_window()
   augroup END
 <
 

--- a/doc/vaffle.txt
+++ b/doc/vaffle.txt
@@ -232,6 +232,17 @@ version, but not supported.
 		customize key mappings, see
 		|vaffle-example-custom-key-mappings|.
 
+*g:vaffle_open_current_split_location*
+                (Default: 'topleft')
+                This option accepts 'topleft' or 'rightbelow'.
+                It changes the behavior of
+                |<Plug>(vaffle-open-current-split)|.
+
+*g:vaffle_open_current_vsplit_location*
+                (Default: 'rightbelow')
+                This option accepts 'topleft' or 'rightbelow'.
+                It changes the behavior of |<Plug>(vaffle-open-current-vsplit)|.
+
 
 ==============================================================================
 5. Examples                                                  *vaffle-examples*

--- a/doc/vaffle.txt
+++ b/doc/vaffle.txt
@@ -232,13 +232,13 @@ version, but not supported.
 		customize key mappings, see
 		|vaffle-example-custom-key-mappings|.
 
-*g:vaffle_open_current_split_location*
+*g:vaffle_open_current_split_position*
                 (Default: 'topleft')
                 This option accepts 'topleft' or 'rightbelow'.
                 It changes the behavior of
                 |<Plug>(vaffle-open-current-split)|.
 
-*g:vaffle_open_current_vsplit_location*
+*g:vaffle_open_current_vsplit_position*
                 (Default: 'rightbelow')
                 This option accepts 'topleft' or 'rightbelow'.
                 It changes the behavior of |<Plug>(vaffle-open-current-vsplit)|.

--- a/plugin/vaffle.vim
+++ b/plugin/vaffle.vim
@@ -36,27 +36,29 @@ command! -bar -nargs=? -complete=dir Vaffle call vaffle#init(<f-args>)
 
 
 " Toggle
-nnoremap <silent> <Plug>(vaffle-toggle-all)       :<C-u>call vaffle#toggle_all()<CR>
-nnoremap <silent> <Plug>(vaffle-toggle-hidden)    :<C-u>call vaffle#toggle_hidden()<CR>
-nnoremap <silent> <Plug>(vaffle-toggle-current)   :<C-u>call vaffle#toggle_current('n')<CR>
-vnoremap <silent> <Plug>(vaffle-toggle-current)   :<C-u>call vaffle#toggle_current('v')<CR>
+nnoremap <silent> <Plug>(vaffle-toggle-all)          :<C-u>call vaffle#toggle_all()<CR>
+nnoremap <silent> <Plug>(vaffle-toggle-hidden)       :<C-u>call vaffle#toggle_hidden()<CR>
+nnoremap <silent> <Plug>(vaffle-toggle-current)      :<C-u>call vaffle#toggle_current('n')<CR>
+vnoremap <silent> <Plug>(vaffle-toggle-current)      :<C-u>call vaffle#toggle_current('v')<CR>
 " Operations for selected items
-nnoremap <silent> <Plug>(vaffle-delete-selected)  :<C-u>call vaffle#delete_selected()<CR>
-nnoremap <silent> <Plug>(vaffle-fill-cmdline)     :<C-u>call vaffle#fill_cmdline()<CR>
-nnoremap <silent> <Plug>(vaffle-move-selected)    :<C-u>call vaffle#move_selected()<CR>
-nnoremap <silent> <Plug>(vaffle-open-selected)    :<C-u>call vaffle#open_selected()<CR>
-nnoremap <silent> <Plug>(vaffle-rename-selected)  :<C-u>call vaffle#rename_selected()<CR>
+nnoremap <silent> <Plug>(vaffle-delete-selected)     :<C-u>call vaffle#delete_selected()<CR>
+nnoremap <silent> <Plug>(vaffle-fill-cmdline)        :<C-u>call vaffle#fill_cmdline()<CR>
+nnoremap <silent> <Plug>(vaffle-move-selected)       :<C-u>call vaffle#move_selected()<CR>
+nnoremap <silent> <Plug>(vaffle-open-selected)       :<C-u>call vaffle#open_selected()<CR>
+nnoremap <silent> <Plug>(vaffle-rename-selected)     :<C-u>call vaffle#rename_selected()<CR>
 " Operations for a item on cursor
-nnoremap <silent> <Plug>(vaffle-open-current)     :<C-u>call vaffle#open_current('')<CR>
-nnoremap <silent> <Plug>(vaffle-open-current-tab) :<C-u>call vaffle#open_current('tab')<CR>
+nnoremap <silent> <Plug>(vaffle-open-current)        :<C-u>call vaffle#open_current('')<CR>
+nnoremap <silent> <Plug>(vaffle-open-current-tab)    :<C-u>call vaffle#open_current('tab')<CR>
+nnoremap <silent> <Plug>(vaffle-open-current-split)  :<C-u>call vaffle#open_current('split')<CR>
+nnoremap <silent> <Plug>(vaffle-open-current-vsplit) :<C-u>call vaffle#open_current('vsplit')<CR>
 " Misc
-nnoremap <silent> <Plug>(vaffle-mkdir)            :<C-u>call vaffle#mkdir()<CR>
-nnoremap <silent> <Plug>(vaffle-new-file)         :<C-u>call vaffle#new_file()<CR>
-nnoremap <silent> <Plug>(vaffle-open-home)        :<C-u>call vaffle#open('~')<CR>
-nnoremap <silent> <Plug>(vaffle-open-parent)      :<C-u>call vaffle#open_parent()<CR>
-nnoremap <silent> <Plug>(vaffle-open-root)        :<C-u>call vaffle#open('/')<CR>
-nnoremap <silent> <Plug>(vaffle-quit)             :<C-u>call vaffle#quit()<CR>
-nnoremap <silent> <Plug>(vaffle-refresh)          :<C-u>call vaffle#refresh()<CR>
+nnoremap <silent> <Plug>(vaffle-mkdir)               :<C-u>call vaffle#mkdir()<CR>
+nnoremap <silent> <Plug>(vaffle-new-file)            :<C-u>call vaffle#new_file()<CR>
+nnoremap <silent> <Plug>(vaffle-open-home)           :<C-u>call vaffle#open('~')<CR>
+nnoremap <silent> <Plug>(vaffle-open-parent)         :<C-u>call vaffle#open_parent()<CR>
+nnoremap <silent> <Plug>(vaffle-open-root)           :<C-u>call vaffle#open('/')<CR>
+nnoremap <silent> <Plug>(vaffle-quit)                :<C-u>call vaffle#quit()<CR>
+nnoremap <silent> <Plug>(vaffle-refresh)             :<C-u>call vaffle#refresh()<CR>
 
 
 let &cpoptions = s:save_cpo

--- a/plugin/vaffle.vim
+++ b/plugin/vaffle.vim
@@ -20,6 +20,8 @@ function! s:set_up_default_config()
         \   'vaffle_force_delete': 0,
         \   'vaffle_show_hidden_files': 0,
         \   'vaffle_use_default_mappings': 1,
+        \   'vaffle_open_current_split_location': 'topleft',
+        \   'vaffle_open_current_vsplit_location': 'rightbelow',
         \ }
 
   for var_name in keys(config_dict)

--- a/plugin/vaffle.vim
+++ b/plugin/vaffle.vim
@@ -20,8 +20,8 @@ function! s:set_up_default_config()
         \   'vaffle_force_delete': 0,
         \   'vaffle_show_hidden_files': 0,
         \   'vaffle_use_default_mappings': 1,
-        \   'vaffle_open_current_split_location': 'topleft',
-        \   'vaffle_open_current_vsplit_location': 'rightbelow',
+        \   'vaffle_open_current_split_position': 'topleft',
+        \   'vaffle_open_current_vsplit_position': 'rightbelow',
         \ }
 
   for var_name in keys(config_dict)


### PR DESCRIPTION
# Objective
* Add mappings `<Plug>(vaffle-open-current-split)` and `<Plug>(vaffle-open-current-vsplit)`

This functions are mentiond at #9.
The default mappings are `s` and `v`.
The locations of the splitten window can be configured by scripts below

```vim-script
function! s:on_filetype_vaffle() abort
    setlocal splitbelow
    setlocal splitright
endfunction

augroup plugin
    autocmd!
    autocmd Filetype vaffle call s:on_filetype_vaffle()
augroup END
```