### PR TITLE
Add new commands to open vaffle buffer

### DIFF
--- a/autoload/vaffle/buffer.vim
+++ b/autoload/vaffle/buffer.vim
@@ -247,4 +247,13 @@ function! vaffle#buffer#save_cursor(item) abort
 endfunction
 
 
+function! vaffle#buffer#save_cursor_at_current_item() abort
+  let env = vaffle#buffer#get_env()
+  let cursor_items = vaffle#item#get_cursor_items(env, 'n')
+  if !empty(cursor_items)
+    call vaffle#buffer#save_cursor(cursor_items[0])
+  endif
+endfunction
+
+
 let &cpoptions = s:save_cpo

--- a/autoload/vaffle/event.vim
+++ b/autoload/vaffle/event.vim
@@ -29,4 +29,11 @@ function! vaffle#event#on_bufenter() abort
 endfunction
 
 
+function! vaffle#event#on_bufleave() abort
+  if vaffle#buffer#is_for_vaffle(bufnr('%'))
+    call vaffle#buffer#save_cursor_at_current_item()
+  endif
+endfunction
+
+
 let &cpoptions = s:save_cpo

--- a/autoload/vaffle/item.vim
+++ b/autoload/vaffle/item.vim
@@ -16,4 +16,20 @@ function! vaffle#item#create(path) abort
 endfunction
 
 
+function! vaffle#item#get_cursor_items(env, mode) abort
+  let items = a:env.items
+  if empty(items)
+    return []
+  endif
+
+  let in_visual_mode = (a:mode ==? 'v')
+  let indexes = in_visual_mode
+        \ ? range(line('''<') - 1, line('''>') - 1)
+        \ : [line('.') - 1]
+  return map(
+        \ copy(indexes),
+        \ 'items[v:val]')
+endfunction
+
+
 let &cpoptions = s:save_cpo

--- a/plugin/vaffle.vim
+++ b/plugin/vaffle.vim
@@ -11,6 +11,7 @@ let g:loaded_vaffle = 1
 augroup vaffle_vim
   autocmd!
   autocmd BufEnter * call vaffle#event#on_bufenter()
+  autocmd BufLeave vaffle://* call vaffle#event#on_bufleave()
 augroup END
 
 

--- a/plugin/vaffle.vim
+++ b/plugin/vaffle.vim
@@ -19,6 +19,8 @@ function! s:set_up_default_config()
         \   'vaffle_auto_cd': 0,
         \   'vaffle_force_delete': 0,
         \   'vaffle_show_hidden_files': 0,
+        \   'vaffle_fixed_window_width': 35,
+        \   'vaffle_fixed_window_height': 12,
         \   'vaffle_use_default_mappings': 1,
         \ }
 
@@ -32,7 +34,12 @@ endfunction
 
 call s:set_up_default_config()
 
-command! -bar -nargs=? -complete=dir Vaffle call vaffle#init(<f-args>)
+command! -bar -nargs=? -complete=dir Vaffle            call vaffle#init(<f-args>)
+command! -bar -nargs=? -complete=dir VaffleTab         call vaffle#init_on_new_window(['tab'], <f-args>)
+command! -bar -nargs=? -complete=dir VaffleSplit       call vaffle#init_on_new_window(['split'], <f-args>)
+command! -bar -nargs=? -complete=dir VaffleSplitFixed  call vaffle#init_on_new_window(['split', 'fixed'], <f-args>)
+command! -bar -nargs=? -complete=dir VaffleVsplit      call vaffle#init_on_new_window(['vsplit'], <f-args>)
+command! -bar -nargs=? -complete=dir VaffleVsplitFixed call vaffle#init_on_new_window(['vsplit', 'fixed'], <f-args>)
 
 
 " Toggle


### PR DESCRIPTION
# Objective
* Add commands
   * VaffleTab        
   * VaffleSplit      
   * VaffleSplitFixed 
   * VaffleVsplit     
   * VaffleVsplitFixed

The windows of `VaffleSplitFixed` and `VaffleVsplitFixed` is fixed size.
It can be configured by `g:vaffle_fixed_window_height` and `g:vaffle_fixed_window_width`.

The window was opened by these command will be closed by `<Plug>(vaffle-quit)`

TODO: write document