### PR TITLE
Fix behavior when dirname includes dollar sign

### DIFF
--- a/autoload/vaffle.vim
+++ b/autoload/vaffle.vim
@@ -154,7 +154,7 @@ endfunction
 
 function! vaffle#open_parent() abort
   let env = vaffle#buffer#get_env()
-  let parent_dir = fnamemodify(env.dir, ':h')
+  let parent_dir = fnameescape(fnamemodify(env.dir, ':h'))
   call vaffle#open(parent_dir)
 endfunction
 

--- a/autoload/vaffle/env.vim
+++ b/autoload/vaffle/env.vim
@@ -29,9 +29,10 @@ endfunction
 
 
 function! vaffle#env#create_items(env) abort
-  let paths = vaffle#compat#glob_list(fnamemodify(a:env.dir, ':p') . '*')
+  let env_dir = fnameescape(fnamemodify(a:env.dir, ':p'))
+  let paths = vaffle#compat#glob_list(env_dir . '*')
   if a:env.shows_hidden_files
-    let hidden_paths = vaffle#compat#glob_list(fnamemodify(a:env.dir, ':p') . '.*')
+    let hidden_paths = vaffle#compat#glob_list(env_dir . '.*')
     " Exclude '.' & '..'
     call filter(hidden_paths, 'match(v:val, ''\(/\|\\\)\.\.\?$'') < 0')
 


### PR DESCRIPTION
## Problem

vaffle.vim behaves wrong on a directory whose path includes a dollar sign.

## Repro steps

On unix-like system.

Preparation: create sample directories.

```
$ ls

$ mkdir -p \$foobar
$ mkdir -p \$foobar/001
$ touch \$foobar/002
```

(`$foobar` is empty)

vimrc:

```
set rtp+=/path/to/vaffle.vim
```

Start Vim with vaffle.vim:

`vim -Nu vimrc .`

Display:

```
  $foobar/
```

Feed key `l` (move into `$foobar`),

Expected:

```
  001/
  002
```

Actual:

```
  /
```

## Cause

A string starting with dollar sign is expanded as env variable by `glob()`, `expand()`.
It should be escaped by `fnameescape()` properly.
