### PR TITLE
Change default behavior of vaffle-open-selected-split/vsplit

### DIFF
--- a/autoload/vaffle/file.vim
+++ b/autoload/vaffle/file.vim
@@ -5,14 +5,14 @@ set cpoptions&vim
 let s:open_mode_to_cmd_single_map = {
       \   '':       'edit',
       \   'tab':    'tabedit',
-      \   'split':  get(g:, 'vaffle_open_selected_split_position', 'topleft') . ' split',
-      \   'vsplit': get(g:, 'vaffle_open_selected_vsplit_position', 'rightbelow') . ' vsplit',
+      \   'split':  get(g:, 'vaffle_open_selected_split_position', '') . ' split',
+      \   'vsplit': get(g:, 'vaffle_open_selected_vsplit_position', '') . ' vsplit',
       \ }
 let s:open_mode_to_cmd_multiple_map = {
       \   '':       'split',
       \   'tab':    'tabedit',
-      \   'split':  get(g:, 'vaffle_open_selected_split_position', 'topleft') . ' split',
-      \   'vsplit': get(g:, 'vaffle_open_selected_vsplit_position', 'rightbelow') . ' vsplit',
+      \   'split':  get(g:, 'vaffle_open_selected_split_position', '') . ' split',
+      \   'vsplit': get(g:, 'vaffle_open_selected_vsplit_position', '') . ' vsplit',
       \ }
 
 

--- a/doc/vaffle.txt
+++ b/doc/vaffle.txt
@@ -234,14 +234,14 @@ version, but not supported.
                 time.
 
 *g:vaffle_open_selected_split_position*
-                (Default: 'topleft')
-                Possible values: 'topleft' or 'rightbelow'
+                (Default: '')
+                Possible values: empty (''), 'topleft' or 'rightbelow'
                 Set the position of the new window of
                 |<Plug>(vaffle-open-selected-split)|.
 
 *g:vaffle_open_selected_vsplit_position*
-                (Default: 'rightbelow')
-                Possible values: 'topleft' or 'rightbelow'
+                (Default: '')
+                Possible values: empty (''), 'topleft' or 'rightbelow'
                 Set the position of the new window of
                 |<Plug>(vaffle-open-selected-vsplit)|.
 

--- a/doc/vaffle.txt
+++ b/doc/vaffle.txt
@@ -235,13 +235,13 @@ version, but not supported.
 
 *g:vaffle_open_selected_split_position*
                 (Default: '')
-                Possible values: empty (''), 'topleft' or 'rightbelow'
+                Possible values: '', 'topleft' or 'rightbelow'
                 Set the position of the new window of
                 |<Plug>(vaffle-open-selected-split)|.
 
 *g:vaffle_open_selected_vsplit_position*
                 (Default: '')
-                Possible values: empty (''), 'topleft' or 'rightbelow'
+                Possible values: '', 'topleft' or 'rightbelow'
                 Set the position of the new window of
                 |<Plug>(vaffle-open-selected-vsplit)|.
 


### PR DESCRIPTION
## Objective 
This PR changes the default behavior of `<Plug>(vaffle-open-selected-split)` and `<Plug>(vaffle-open-selected-vsplit)` following vim's default behavior of `split` and `vsplit`.
It solves #24 .