### PR TITLE
Fix #33: Do init when enter to the deleted vaffle buffer

### DIFF
--- a/autoload/vaffle/buffer.vim
+++ b/autoload/vaffle/buffer.vim
@@ -129,6 +129,11 @@ function! vaffle#buffer#is_for_vaffle(bufnr) abort
 endfunction
 
 
+function! vaffle#buffer#was_for_vaffle(bufnr) abort
+  return vaffle#buffer#is_for_vaffle(a:bufnr) && !exists('b:vaffle')
+endfunction
+
+
 function! vaffle#buffer#redraw() abort
   setlocal modifiable
 

--- a/autoload/vaffle/event.vim
+++ b/autoload/vaffle/event.vim
@@ -13,9 +13,12 @@ function! vaffle#event#on_bufenter() abort
   call s:newtralize_netrw()
 
   let bufnr = bufnr('%')
+  let was_vaffle_buffer = vaffle#buffer#was_for_vaffle(bufnr)
   let path = expand('%:p')
 
-  let should_init = isdirectory(path)
+  let should_init = was_vaffle_buffer
+        \ || isdirectory(path)
+
   if !should_init
     " Store bufnr of non-directory buffer
     " for restoring previous buffer when quitting


### PR DESCRIPTION
When enter to deleted vaffle buffer, `b:vaffle` doesn't exist so needs do init.