### PR TITLE
Fix bug of unclosable buffer

### DIFF
--- a/autoload/vaffle/buffer.vim
+++ b/autoload/vaffle/buffer.vim
@@ -129,11 +129,6 @@ function! vaffle#buffer#is_for_vaffle(bufnr) abort
 endfunction
 
 
-function! vaffle#buffer#was_for_vaffle(bufnr) abort
-  return vaffle#buffer#is_for_vaffle(a:bufnr) && !exists('b:vaffle')
-endfunction
-
-
 function! vaffle#buffer#redraw() abort
   setlocal modifiable
 

--- a/autoload/vaffle/event.vim
+++ b/autoload/vaffle/event.vim
@@ -9,20 +9,35 @@ function! s:newtralize_netrw() abort
 endfunction
 
 
+function! s:should_init(bufnr, path) abort
+  let for_vaffle = vaffle#buffer#is_for_vaffle(a:bufnr)
+
+  if for_vaffle && !exists('b:vaffle')
+    " Deleted Vaffle buffer should be initialized
+    return 1
+  endif
+
+  if for_vaffle
+    " Living Vaffle buffer should not be initialized
+    return 0
+  endif
+
+  return isdirectory(a:path)
+endfunction
+
+
 function! vaffle#event#on_bufenter() abort
   call s:newtralize_netrw()
 
   let bufnr = bufnr('%')
-  let was_vaffle_buffer = vaffle#buffer#was_for_vaffle(bufnr)
   let path = expand('%:p')
 
-  let should_init = was_vaffle_buffer
-        \ || isdirectory(path)
-
-  if !should_init
-    " Store bufnr of non-directory buffer
-    " for restoring previous buffer when quitting
-    call vaffle#window#store_non_vaffle_buffer(bufnr)
+  if !s:should_init(bufnr, path)
+    if !vaffle#buffer#is_for_vaffle(bufnr)
+      " Store bufnr of non-directory, non-vaffle buffer
+      " for restoring previous buffer when quitting
+      call vaffle#window#store_non_vaffle_buffer(bufnr)
+    endif
     return
   endif
 

--- a/test/e2e/duplication.vim
+++ b/test/e2e/duplication.vim
@@ -2,6 +2,11 @@ let s:suite = themis#suite('vaffle_e2e_duplication')
 let s:assert = themis#helper('assert')
 
 
+function! s:suite.before_each() abort
+  %bwipeout!
+endfunction
+
+
 function! s:suite.test_duplicate_and_select() abort
   Vaffle test/e2e/files/duplication
   " Show hidden files
@@ -40,6 +45,7 @@ endfunction
 
 function! s:suite.test_duplicate_and_quit() abort
   Vaffle test/e2e/files/duplication
+
   " Split the buffer
   execute "normal \<C-w>v"
   " Quit
@@ -48,9 +54,23 @@ function! s:suite.test_duplicate_and_quit() abort
   call s:assert.equals(
         \ bufname('%'),
         \ '',
-        \ 'Duplicated Vaffle should quit')
+        \ 'Duplicated Vaffle should be closed')
   call s:assert.equals(
         \ &filetype,
         \ '',
-        \ 'Duplicated Vaffle should quit')
+        \ 'Duplicated Vaffle should be closed')
+
+  " Focus another buffer
+  execute "normal \<C-w>w"
+  " Quit another buffer
+  normal q
+
+  call s:assert.equals(
+        \ bufname('%'),
+        \ '',
+        \ 'Duplicated Vaffle should be closed')
+  call s:assert.equals(
+        \ &filetype,
+        \ '',
+        \ 'Duplicated Vaffle should be closed')
 endfunction

--- a/test/e2e/uncategorized.vim
+++ b/test/e2e/uncategorized.vim
@@ -2,6 +2,11 @@ let s:suite = themis#suite('vaffle_e2e_uncategorized')
 let s:assert = themis#helper('assert')
 
 
+function! s:suite.before_each() abort
+  %bwipeout!
+endfunction
+
+
 function! s:get_listed_buffers() abort
   return filter(range(1, bufnr('$')), 'bufexists(v:val) && buflisted(v:val)')
 endfunction


### PR DESCRIPTION
```vim
  " Split the buffer
  execute "normal \<C-w>v"
  " Quit
  normal q

  " Focus another buffer
  execute "normal \<C-w>w"
  " Quit another buffer
  normal q
```