### PR TITLE
[add] support for icon-font

### DIFF
--- a/autoload/vaffle/renderer.vim
+++ b/autoload/vaffle/renderer.vim
@@ -3,9 +3,16 @@ set cpoptions&vim
 
 
 function! vaffle#renderer#render_item(item) abort
-  return printf('%s %s',
-        \ a:item.selected ? '*' : ' ',
-        \ a:item.basename . (a:item.is_dir ? '/' : ''))
+  if get(g:, 'vaffle_render_custom_icon', '') !=# ''
+    return printf('%s %s %s',
+          \ a:item.selected ? '*' : ' ',
+          \ call(g:vaffle_render_custom_icon, [a:item]),
+          \ a:item.basename . (a:item.is_dir ? '/' : ''))
+  else
+    return printf('%s %s',
+          \ a:item.selected ? '*' : ' ',
+          \ a:item.basename . (a:item.is_dir ? '/' : ''))
+  endif
 endfunction
 
 

--- a/doc/vaffle.txt
+++ b/doc/vaffle.txt
@@ -247,6 +247,19 @@ version, but not supported.
   If disabled, Vaffle doesn't set up the default mappings. To customize key
   mappings, see |vaffle-example-custom-key-mappings|.
 
+*g:vaffle_render_custom_icon*
+  (Default: '')
+  If enable, Vaffle add icon font support. use like this,
+
+  example : Writing this config your vimrc >
+
+  function! RenderMyFavoriteIcon(item)
+    return WebDevIconsGetFileTypeSymbol(a:item.basename, a:item.is_dir)
+  endfunction
+  let g:vaffle_render_custom_icon = 'RenderMyFavoriteIcon'
+
+<  e.g : using vim-devicons       <https://github.com/ryanoasis/vim-devicons>
+
 
 ==============================================================================
 5. Examples                                                  *vaffle-examples*

--- a/syntax/vaffle.vim
+++ b/syntax/vaffle.vim
@@ -2,16 +2,16 @@ if exists('b:current_syntax')
   finish
 endif
 
-
 syn match vaffleDirectory '^  .\+/$'
 syn match vaffleHidden '^  \..\+$'
+syn match vaffleHiddenWithIcon '^  . \..\+$'
 syn match vaffleSelected '^* .\+$'
 syn match vaffleNoItems '^  (no items)$'
 
 hi! def link vaffleDirectory Directory
 hi! def link vaffleHidden Comment
+hi! def link vaffleHiddenWithIcon Comment
 hi! def link vaffleNoItems Comment
 hi! def link vaffleSelected Special
-
 
 let b:current_syntax = 'vaffle'


### PR DESCRIPTION
Hello, @cocopon .
Thanks for creating great Vim plugin.
I wrote a patch to support vim-devicons.

### vim-devicons url

> https://github.com/ryanoasis/vim-devicons

This patch can rendering icon font.
Could you check this PR?

## screen shot

<img width="274" alt="スクリーンショット 2020-05-02 0 31 46" src="https://user-images.githubusercontent.com/36619465/80818388-0b958300-8c0e-11ea-87f6-4ad173bd285a.png">

<img width="272" alt="スクリーンショット 2020-05-02 0 31 54" src="https://user-images.githubusercontent.com/36619465/80818395-0fc1a080-8c0e-11ea-9ec8-c148c4406a55.png">

<img width="289" alt="スクリーンショット 2020-05-02 0 47 07" src="https://user-images.githubusercontent.com/36619465/80818620-7fd02680-8c0e-11ea-8fd6-6f3493fd69df.png">

