### PR TITLE
[add] github actions and some vim version in test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        vim_version:
+        - 'v8.2.0000'
+        - 'v8.1.0000'
+        - 'v8.0.0000'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@master
+
+    - name: Checkout vim-themis
+      uses: actions/checkout@master
+      with:
+        repository: thinca/vim-themis
+        path: vim-themis
+
+    - name: Setup Vim
+      uses: thinca/action-setup-vim@v1
+      with:
+        vim_version: ${{ matrix.vim_version }}
+
+    - name: echo Vim version
+      run: vim --version
+
+    - name: Test
+      env:
+        THEMIS_VIM: ${{ steps.vim.outputs.executable }}
+      run: ./vim-themis/bin/themis --reporter spec


### PR DESCRIPTION
Hello, cocopon.
Thanks for creating great Vim plugin.
I add github-actions.

- This removes the circleci's dependency.
- Add more vim version in test   e.g: vim8.1, vim8.2...

Could you check this PR?
If you don't need this pull request, feel free to close it.


## reference
> https://github.com/kazukazuinaina/vaffle.vim/pull/1/checks?check_run_id=798523891

> https://github.com/thinca/action-setup-vim