### PR TITLE
Enable going back to previous buffer from a vuffle buffer

### DIFF
--- a/autoload/vaffle/win_env.vim
+++ b/autoload/vaffle/win_env.vim
@@ -4,7 +4,8 @@ set cpoptions&vim
 
 function! vaffle#win_env#create() abort
   let env = {}
-  let env.non_vaffle_bufnr = -1
+  let env.altbuf = -1
+  let env.prevbuf = -1
   return env
 endfunction
 

--- a/autoload/vaffle/window.vim
+++ b/autoload/vaffle/window.vim
@@ -1,22 +1,23 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
+function! s:buffer_valid(bufnr)
+  return bufexists(a:bufnr) && (getbufvar(a:bufnr, '&filetype') !=? 'vaffle')
+endfunction
+
 
 function! vaffle#window#init() abort
   let win_env = extend(
         \ vaffle#win_env#create(),
         \ get(w:, 'vaffle', {}))
 
-  if win_env.non_vaffle_bufnr == bufnr('%')
-    " Exclude empty buffer used for Vaffle
-    " For example:
-    " :enew
-    "   Created new empty buffer (bufnr: 2)
-    "   Updated `non_vaffle_bufnr` (= 2)
-    " :Vaffle
-    "   Used created buffer (bufnr: 2) for Vaffle
-    "   `non_vaffle_bufnr` is 2, but should not restore it
-    let win_env.non_vaffle_bufnr = -1
+
+  if has_key(win_env, 'altbuf') && win_env.altbuf == bufnr('%')
+    let win_env.altbuf = -1
+  endif
+
+  if has_key(win_env, 'prevbuf') && win_env.prevbuf == bufnr('%')
+    let win_env.prevbuf = -1
   endif
 
   call vaffle#window#set_env(win_env)
@@ -25,7 +26,23 @@ endfunction
 
 function! vaffle#window#store_non_vaffle_buffer(bufnr) abort
   let win_env = vaffle#window#get_env()
-  let win_env.non_vaffle_bufnr = a:bufnr
+
+  let d = {}
+  let d.prevbuf = s:buffer_valid(a:bufnr) || !has_key(win_env, 'prevbuf')
+    \ ? 0+a:bufnr : win_env.prevbuf
+  if !s:buffer_valid(d.prevbuf)
+    let d.prevbuf = has_key(win_env, 'prevbuf') && s:buffer_valid(win_env.prevbuf)
+        \ ? win_env.prevbuf : bufnr('#')
+  endif
+
+  let d.altbuf = s:buffer_valid(bufnr('#')) || !has_key(win_env, 'altbuf')
+    \ ? 0+bufnr('#') : win_env.altbuf
+
+  if has_key(win_env, 'altbuf') && (d.altbuf == d.prevbuf || !s:buffer_valid(d.altbuf))
+    let d.altbuf = win_env.altbuf
+  endif
+
+  let win_env = d
   call vaffle#window#set_env(win_env)
 endfunction
 


### PR DESCRIPTION
# Objective 

This pull request removes th non_vaffle_bufnr variable and adds two variables *altbuf* and *prevbuf*

this all taken from dirivish.vim