### PR TITLE
keep the alternate file and fix interference with/by the projectionist plugin

### DIFF
--- a/autoload/vaffle/buffer.vim
+++ b/autoload/vaffle/buffer.vim
@@ -94,7 +94,7 @@ endfunction
 function! vaffle#buffer#init(filer) abort
   " Give unique name to buffer to avoid unwanted sync
   " between different windows
-  execute printf('silent file %s',
+  execute printf('silent! keepalt edit %s',
         \ s:generate_unique_bufname(a:filer.dir))
 
   if g:vaffle_use_default_mappings


### PR DESCRIPTION
* Keep the alternate file (keepalt) - this allows a user to navigate
  around using vaffle, decide nothing needs to be done, and press CTRL-6
  and go back to editing the file he was in
* use 'edit' instead of 'file'. Using vaffle was failing when 'file' was
  used because it was interfering with the 'projectionist' plugin