### PR TITLE
[#62] Add header showing current path

### DIFF
--- a/autoload/vaffle.vim
+++ b/autoload/vaffle.vim
@@ -27,13 +27,19 @@ function! s:get_cursor_items(filer, mode) abort
     return []
   endif
 
+  " User clicked the header that is the current dir
+  if g:vaffle_show_header == 1 && line('.') == 1
+    " call vaffle#open_parent()
+    return []
+  endif
+
   let in_visual_mode = (a:mode ==? 'v')
   let lnums = in_visual_mode
         \ ? range(line('''<'), line('''>'))
         \ : [line('.')]
   return map(
         \ copy(lnums),
-        \ 'items[s:lnum_to_item_index(v:val)]')
+        \ 'items[s:lnum_to_item_index(v:val) - g:vaffle_show_header]')
 endfunction
 
 
@@ -85,7 +91,7 @@ function! vaffle#init(...) abort
   let extracted_path = vaffle#buffer#extract_path_from_bufname(path)
   let path = !empty(extracted_path)
         \ ? extracted_path
-        \ : path 
+        \ : path
 
   let path = fnamemodify(path, ':p')
 
@@ -120,7 +126,6 @@ function! vaffle#init(...) abort
     return
   endtry
 endfunction
-
 
 function! vaffle#refresh() abort
   call s:keep_buffer_singularity()
@@ -270,7 +275,7 @@ function! vaffle#quit() abort
   " the case where cur == alt is when there are no other
   " buffers except for vaffle
   if bufexists(alt) && cur != alt
-    execute printf('buffer! %d', alt) 
+    execute printf('buffer! %d', alt)
     return
   endif
 

--- a/autoload/vaffle/buffer.vim
+++ b/autoload/vaffle/buffer.vim
@@ -135,7 +135,12 @@ function! vaffle#buffer#redraw() abort
   silent keepjumps %delete _
 
   let filer = vaffle#buffer#get_filer()
-  call setline(1, vaffle#renderer#render_filer(filer.items))
+
+  if g:vaffle_show_header
+    call setline(1, vaffle#renderer#render_header(filer.dir))
+  endif
+
+  call setline(1+g:vaffle_show_header, vaffle#renderer#render_filer(filer.items))
 
   setlocal nomodifiable
   setlocal nomodified
@@ -168,7 +173,7 @@ function! vaffle#buffer#redraw_item(item) abort
   setlocal modifiable
 
   let lnum = a:item.index + 1
-  call setline(lnum, vaffle#renderer#render_item(a:item))
+  call setline(lnum + g:vaffle_show_header, vaffle#renderer#render_item(a:item))
 
   setlocal nomodifiable
   setlocal nomodified

--- a/autoload/vaffle/renderer.vim
+++ b/autoload/vaffle/renderer.vim
@@ -24,6 +24,9 @@ function! vaffle#renderer#render_filer(items) abort
   return map(copy(a:items), 'vaffle#renderer#render_item(v:val)')
 endfunction
 
+function! vaffle#renderer#render_header(path)
+   return fnamemodify(a:path, ':p') . ':'
+endfunction
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/doc/vaffle.txt
+++ b/doc/vaffle.txt
@@ -232,6 +232,11 @@ version, but not supported.
   If enabled, Vaffle shows hidden files by default. You can toggle the option
   with |<Plug>(vaffle-toggle-hidden)| any time.
 
+*g:vaffle_show_header*
+  (Default: 0)
+  Possible values: 0, 1
+  If enabled, shows the current path in a header above the listed files
+
 *g:vaffle_open_selected_split_position*
   (Default: '')
   Possible values: '', 'topleft' or 'rightbelow'
@@ -251,7 +256,6 @@ version, but not supported.
   (Default: '')
   If you want to render custom file type icon for each item, specify
   the function name. See |vaffle-example-file-type-icons|.
-
 
 ==============================================================================
 5. Examples                                                  *vaffle-examples*

--- a/plugin/vaffle.vim
+++ b/plugin/vaffle.vim
@@ -22,6 +22,7 @@ function! s:set_up_default_config()
         \   'vaffle_use_default_mappings': 1,
         \   'vaffle_open_current_split_position': 'topleft',
         \   'vaffle_open_current_vsplit_position': 'rightbelow',
+        \   'vaffle_show_header': 0,
         \ }
 
   for var_name in keys(config_dict)

--- a/syntax/vaffle.vim
+++ b/syntax/vaffle.vim
@@ -7,11 +7,13 @@ syn match vaffleHidden '^  \..\+$'
 syn match vaffleHiddenWithIcon '^  . \..\+$'
 syn match vaffleSelected '^* .\+$'
 syn match vaffleNoItems '^  (no items)$'
+syn match vaffleHeader '^\S*:'
 
 hi! def link vaffleDirectory Directory
 hi! def link vaffleHidden Comment
 hi! def link vaffleHiddenWithIcon Comment
 hi! def link vaffleNoItems Comment
 hi! def link vaffleSelected Special
+hi! def link vaffleHeader Special
 
 let b:current_syntax = 'vaffle'


### PR DESCRIPTION
Adds an option g:vaffle_show_header to show a header showing the current path.

It is by default disabled, so nothing changes if untouched.

The docs.txt have been updated as well to reflect the new option.